### PR TITLE
added content type header for es6 compatibility

### DIFF
--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -148,7 +148,7 @@ func (e *ElasticsearchExecutor) buildRequest(queryInfo *tsdb.Query, timeRange *t
 	if err != nil {
 		return nil, err
 	}
-
+	req.Header.Add("Content-Type", "application/json")
 	if queryInfo.DataSource.BasicAuth {
 		req.SetBasicAuth(queryInfo.DataSource.BasicAuthUser, queryInfo.DataSource.BasicAuthPassword)
 	}


### PR DESCRIPTION
ES6 compatibility requires content-type header for elasticsearch tsdb client.